### PR TITLE
Enable XOR for V3 API

### DIFF
--- a/DLsite-Play-Downloader-vue/src/dlsiteplay-enc-detector/xor.js
+++ b/DLsite-Play-Downloader-vue/src/dlsiteplay-enc-detector/xor.js
@@ -163,7 +163,7 @@ const hookApiV2Work = () => {
 
     const patterns = [
       /\/api\/v2\/work\/.+$/,
-      /\/api\/v3\/viewer\/token\/.+$/,
+      /\/api\/viewer\/work\/.+$/,
       /\/api\/comipo\/v2\/work\/.+$/
     ];
 

--- a/DLsite-Play-Downloader-vue/src/dlsiteplay-enc-detector/xor.js
+++ b/DLsite-Play-Downloader-vue/src/dlsiteplay-enc-detector/xor.js
@@ -163,6 +163,7 @@ const hookApiV2Work = () => {
 
     const patterns = [
       /\/api\/v2\/work\/.+$/,
+      /\/api\/v3\/viewer\/token\/.+$/,
       /\/api\/comipo\/v2\/work\/.+$/
     ];
 


### PR DESCRIPTION
I was running into issues downloading and noticed that Player isn't using the V2 API for me. Found this endpoint that's being called and provides the correct metadata to allow the downloads.